### PR TITLE
Fix load / unload of pages

### DIFF
--- a/src/dataset.js
+++ b/src/dataset.js
@@ -68,11 +68,11 @@ export default class Dataset {
       next.pageOffset = pageOffset;
       var pages = next.pages;
 
-      var minLoadHorizon = Math.max(pageOffset - next.loadHorizon, 0);
-      var maxLoadHorizon = Math.min(next.stats.totalPages || Infinity, pageOffset + next.loadHorizon);
+      var minLoadHorizon = Math.max(Math.floor(readOffset / next.pageSize) - next.loadHorizon, 0);
+      var maxLoadHorizon = Math.min(next.stats.totalPages || Infinity, Math.ceil(readOffset / next.pageSize) + next.loadHorizon);
 
-      var minUnloadHorizon = Math.max(pageOffset - next.unloadHorizon, 0);
-      var maxUnloadHorizon = Math.min(next.stats.totalPages || Infinity, pageOffset + next.unloadHorizon, pages.length);
+      var minUnloadHorizon = Math.max(Math.floor(readOffset / next.pageSize) - next.unloadHorizon, 0);
+      var maxUnloadHorizon = Math.min(next.stats.totalPages || Infinity, Math.ceil(readOffset / next.pageSize) + next.unloadHorizon, pages.length);
 
       // Unload Pages outside the `unloadHorizons`
       for (i = 0; i < minUnloadHorizon; i += 1) {


### PR DESCRIPTION
Load the page the moment the end of the load horizon "breaches" the
first record of the page when incrementing.
Load the page the moment the beginning of the load horizon "breaches"
the last record of the page when decrementing.
Unload the page the moment the beginning of the unload horizon "passes" the
last record of the page when incrementing.
Unload the page the moment the end of the unload horizon "passes"
the first record of the page when decrementing.