### PR TITLE
Records lazy get

### DIFF
--- a/src/dataset.js
+++ b/src/dataset.js
@@ -10,7 +10,7 @@ class State {
     this.stats = {
       totalPages: undefined
     };
-    this.totalSize = 0;
+    this.length = 0;
   }
 
   update(change) {
@@ -19,7 +19,7 @@ class State {
     next.isResolved = this.isResolved;
     next.isRejected = this.isRejected;
     next.isSettled = this.isSettled;
-    next.totalSize = this.totalSize;
+    next.length = this.length;
     next.pageSize = this.pageSize;
     next.loadHorizon = this.loadHorizon;
     next.unloadHorizon = this.unloadHorizon;
@@ -30,10 +30,6 @@ class State {
     change.call(this, next);
     next.pages = Object.freeze(next.pages);
     return next;
-  }
-
-  get length() {
-    return this.totalSize;
   }
 
   get(index) {
@@ -145,7 +141,7 @@ export default class Dataset {
   }
 
   _adjustTotalRecords(state) {
-    state.totalSize = state.pages.reduce(function(length, page) {
+    state.length = state.pages.reduce(function(length, page) {
       return length + page.records.length;
     }, 0);
   }

--- a/src/dataset.js
+++ b/src/dataset.js
@@ -34,9 +34,13 @@ class State {
 
   get(index) {
     let pageOffset = Math.floor(index / this.pageSize);
-    let recordOffset = index % this.pageSize;
-    let records = this.pages[pageOffset].data;
-    return records[recordOffset];
+    let records = this.pages[pageOffset];
+    if (records) {
+      let recordOffset = index % this.pageSize;
+      return records.data[recordOffset];
+    } else {
+      return undefined;
+    }
   }
 }
 

--- a/test/dataset-test.js
+++ b/test/dataset-test.js
@@ -94,11 +94,10 @@ describe("Dataset", function() {
         expect(this.state.pages[0].isResolved).to.be.true;
       });
       it('loads a single page of records', function () {
-        var page = this.state.pages[0];
-        var records = page.records;
-        var content = this.state.get(0);
-        expect(records.length).to.equal(this.recordsPerPage);
-        expect(content.name).to.equal('Record 0');
+        var record_0 = this.state.get(0);
+        var record_10 = this.state.get(10);
+        expect(record_0).to.exist;
+        expect(record_10).to.not.exist;
       });
     });
 
@@ -246,12 +245,10 @@ describe("Dataset", function() {
         });
 
         it('loads a single page of records', function () {
-          var page = this.state.pages[0];
-          var records = page.records;
-          var content = this.state.get(0);
-          expect(records).to.be.instanceOf(Array);
-          expect(records.length).to.equal(this.recordsPerPage);
-          expect(content.name).to.equal('Record 0');
+          var record_0 = this.state.get(0);
+          var record_10 = this.state.get(10);
+          expect(record_0).to.exist;
+          expect(record_10).to.not.exist;
         });
 
         describe("loading the next page", function() {
@@ -300,19 +297,16 @@ describe("Dataset", function() {
         });
 
         it('loads a single page of records before the offset', function () {
-          var beforeOffsetResolvedPages = this.state.pages[1];
-          var records = beforeOffsetResolvedPages.records;
-          var content = this.state.get(10);
-          expect(records.length).to.equal(this.recordsPerPage);
-          expect(content.name).to.equal('Record 10');
+          let index = this.initialReadOffset - this.recordsPerPage;
+          var record = this.state.get(index);
+          expect(record).to.exist;
         });
 
-        it('loads a single page of records after the offset', function () {
-          var afterOffsetResolvedPages = this.state.pages[2];
-          var records = afterOffsetResolvedPages.records;
-          var content = records[0].content;
-          expect(records.length).to.equal(this.recordsPerPage);
-          expect(content.name).to.equal('Record 20');
+        it('loads a single page of records at the offset', function () {
+          let index = this.initialReadOffset;
+          var record = this.state.get(index);
+          expect(record).to.exist;
+          expect(record.name).to.equal('Record 20');
         });
       });
 

--- a/test/dataset-test.js
+++ b/test/dataset-test.js
@@ -797,26 +797,5 @@ describe("Dataset", function() {
         });
       });
     });
-
-    describe.skip("with no fetch function", function() {
-      it("emits an observation of the state");
-      it("indicates that the dataset is not doing any loading");
-    });
-
-    describe.skip("with a fetch function and the default load horizon", function() {
-      it("requests the first page");
-      it("now has a requested page");
-      it("indicates that the dataset is now loading");
-      it("indicates that the first page is loading");
-      describe("when the first page resolves", function() {
-        it("integrates the statistics");
-        it("reflects the total number of records");
-        it("reflects the total number of pages");
-        it("indicates that the dataset is no longer loading");
-        it("indicates that the page is no longer loading");
-        it("contains empty objects for the items that have not even been requested");
-        it("contains unequested pages for the pages that have not been requested");
-      });
-    });
   });
 });

--- a/test/dataset-test.js
+++ b/test/dataset-test.js
@@ -50,8 +50,11 @@ describe("Dataset", function() {
           this.dataset.setReadOffset(0);
         });
         it("begins the process of fetching a page", function() {
+          let record = this.dataset.state.get(0);
           expect(this.server.requests.length).to.equal(1);
           expect(this.server.requests[0]).to.be.instanceOf(PageRequest);
+          expect(this.dataset.state.totalSize).to.equal(10);
+          expect(record).to.be.empty;
         });
       });
     });
@@ -93,7 +96,7 @@ describe("Dataset", function() {
       it('loads a single page of records', function () {
         var page = this.state.pages[0];
         var records = page.records;
-        var content = records[0].content;
+        var content = this.state.get(0);
         expect(records.length).to.equal(this.recordsPerPage);
         expect(content.name).to.equal('Record 0');
       });
@@ -198,7 +201,7 @@ describe("Dataset", function() {
         });
 
         it('loads a single page of records', function () {
-          expect(this.state.records.length).to.equal(this.recordsPerPage);
+          expect(this.state.length).to.equal(this.recordsPerPage);
         });
 
         describe("at an incremented readOffset within the same page", function() {
@@ -222,7 +225,7 @@ describe("Dataset", function() {
             expect(this.state).not.to.equal(this.prevState);
           });
           it("loads an additional page", function() {
-            expect(this.state.records.length).to.equal(2 * this.recordsPerPage);
+            expect(this.state.length).to.equal(2 * this.recordsPerPage);
           });
         });
       });
@@ -245,7 +248,7 @@ describe("Dataset", function() {
         it('loads a single page of records', function () {
           var page = this.state.pages[0];
           var records = page.records;
-          var content = records[0].content;
+          var content = this.state.get(0);
           expect(records).to.be.instanceOf(Array);
           expect(records.length).to.equal(this.recordsPerPage);
           expect(content.name).to.equal('Record 0');
@@ -276,6 +279,7 @@ describe("Dataset", function() {
 
         it('initializes all pages up to the loadHorizon', function () {
           expect(this.state.pages.length).to.equal(3);
+          expect(this.state.length).to.equal(30);
         });
 
         it('loads page 0 as an unrequested page', function () {
@@ -290,16 +294,15 @@ describe("Dataset", function() {
         });
 
         it("has an empty set of records on the first page", function() {
-          var unrequestedPage = this.state.pages[0];
-          var records = unrequestedPage.records;
-          expect(records.length).to.equal(10);
-          expect(records[0].content).to.be.empty;
+          var record = this.state.get(0);
+          expect(record).to.be.empty;
+
         });
 
         it('loads a single page of records before the offset', function () {
           var beforeOffsetResolvedPages = this.state.pages[1];
           var records = beforeOffsetResolvedPages.records;
-          var content = records[0].content;
+          var content = this.state.get(10);
           expect(records.length).to.equal(this.recordsPerPage);
           expect(content.name).to.equal('Record 10');
         });
@@ -329,26 +332,22 @@ describe("Dataset", function() {
         });
 
         it("does not have data defined on the first page", function() {
-          var unrequestedPage = this.state.pages[0];
-          var records = unrequestedPage.records;
-          expect(records.length).to.equal(10);
-          expect(records[0].content).to.be.empty;
+          var record = this.state.get(0);
+          expect(record).to.be.empty;
         });
 
         it('loads a single page of records before the offset', function () {
           var beforeOffsetResolvedPages = this.state.pages[1];
-          var records = beforeOffsetResolvedPages.records;
-          var content = records[0].content;
+          var record = this.state.get(10);
           expect(beforeOffsetResolvedPages.isRequested).to.be.true;
-          expect(content.name).to.equal('Record 10');
+          expect(record.name).to.equal('Record 10');
         });
 
         it('loads a single page of records after the offset', function () {
           var afterOffsetResolvedPages = this.state.pages[2];
-          var records = afterOffsetResolvedPages.records;
-          var content = records[0].content;
+          var record = this.state.get(20);
           expect(afterOffsetResolvedPages.isRequested).to.be.true;
-          expect(content.name).to.equal('Record 20');
+          expect(record.name).to.equal('Record 20');
         });
 
         describe("incrementing the readOffset by the unload horizon", function() {
@@ -360,6 +359,7 @@ describe("Dataset", function() {
 
           it('initializes all pages up to the loadHorizon', function () {
             expect(this.state.pages.length).to.equal(5);
+            expect(this.state.length).to.equal(50);
           });
 
           it("unloads the page before the previous offset", function() {
@@ -374,18 +374,16 @@ describe("Dataset", function() {
 
           it('loads a single page of records before the offset', function () {
             var beforeOffsetResolvedPages = this.state.pages[3];
-            var records = beforeOffsetResolvedPages.records;
-            var content = records[0].content;
+            var record = this.state.get(30);
             expect(beforeOffsetResolvedPages.isRequested).to.be.true;
-            expect(content.name).to.equal('Record 30');
+            expect(record.name).to.equal('Record 30');
           });
 
           it('loads a single page of records after the offset', function () {
             var afterOffsetResolvedPages = this.state.pages[4];
-            var records = afterOffsetResolvedPages.records;
-            var content = records[0].content;
+            var record = this.state.get(40);
             expect(afterOffsetResolvedPages.isRequested).to.be.true;
-            expect(content.name).to.equal('Record 40');
+            expect(record.name).to.equal('Record 40');
           });
         });
 
@@ -402,26 +400,23 @@ describe("Dataset", function() {
 
           it('loads a single page of records before the offset', function () {
             var beforeOffsetResolvedPages = this.state.pages[1];
-            var records = beforeOffsetResolvedPages.records;
-            var content = records[0].content;
+            var record = this.state.get(10);
             expect(beforeOffsetResolvedPages.isRequested).to.be.true;
-            expect(content.name).to.equal('Record 10');
+            expect(record.name).to.equal('Record 10');
           });
 
           it('loads a single page of records at the offset', function () {
             var atOffsetResolvedPages = this.state.pages[2];
-            var records = atOffsetResolvedPages.records;
-            var content = records[0].content;
+            var record = this.state.get(20);
             expect(atOffsetResolvedPages.isRequested).to.be.true;
-            expect(content.name).to.equal('Record 20');
+            expect(record.name).to.equal('Record 20');
           });
 
           it('loads a single page of records after the offset', function () {
             var afterOffsetResolvedPages = this.state.pages[3];
-            var records = afterOffsetResolvedPages.records;
-            var content = records[0].content;
+            var record = this.state.get(30);
             expect(afterOffsetResolvedPages.isRequested).to.be.true;
-            expect(content.name).to.equal('Record 30');
+            expect(record.name).to.equal('Record 30');
           });
         });
 
@@ -438,26 +433,23 @@ describe("Dataset", function() {
 
           it('loads a single page of records before the offset', function () {
             var beforeOffsetResolvedPages = this.state.pages[0];
-            var records = beforeOffsetResolvedPages.records;
-            var content = records[0].content;
+            var record = this.state.get(0);
             expect(beforeOffsetResolvedPages.isRequested).to.be.true;
-            expect(content.name).to.equal('Record 0');
+            expect(record).to.not.be.empty;
           });
 
           it('loads a single page of records at the offset', function () {
             var atOffsetResolvedPages = this.state.pages[1];
-            var records = atOffsetResolvedPages.records;
-            var content = records[0].content;
+            var record = this.state.get(10);
             expect(atOffsetResolvedPages.isRequested).to.be.true;
-            expect(content.name).to.equal('Record 10');
+            expect(record).to.not.be.empty;
           });
 
           it('loads a single page of records after the offset', function () {
             var afterOffsetResolvedPages = this.state.pages[2];
-            var records = afterOffsetResolvedPages.records;
-            var content = records[0].content;
+            var record = this.state.get(20);
             expect(afterOffsetResolvedPages.isRequested).to.be.true;
-            expect(content.name).to.equal('Record 20');
+            expect(record).to.not.be.empty;
           });
         });
 
@@ -478,19 +470,13 @@ describe("Dataset", function() {
           });
 
           it('loads a single page of records before the offset', function () {
-            var beforeOffsetResolvedPages = this.state.pages[0];
-            var records = beforeOffsetResolvedPages.records;
-            var content = records[0].content;
-            expect(records.length).to.equal(this.recordsPerPage);
-            expect(content.name).to.equal('Record 0');
+            var record = this.state.get(0);
+            expect(record).to.not.be.empty;
           });
 
           it('loads a single page of records after the offset', function () {
-            var afterOffsetResolvedPages = this.state.pages[1];
-            var records = afterOffsetResolvedPages.records;
-            var content = records[0].content;
-            expect(records.length).to.equal(this.recordsPerPage);
-            expect(content.name).to.equal('Record 10');
+            var record = this.state.get(10);
+            expect(record).to.not.be.empty;
           });
         });
       });

--- a/test/dataset-test.js
+++ b/test/dataset-test.js
@@ -36,7 +36,7 @@ describe("Dataset", function() {
 
       it("initializes the state", function() {
         expect(this.dataset.state).to.be.instanceOf(Object);
-        expect(this.dataset.state.totalSize).to.equal(0);
+        expect(this.dataset.state.length).to.equal(0);
         expect(this.dataset.state.loadHorizon).to.equal(1);
         expect(this.dataset.state.unloadHorizon).to.equal(Infinity);
       });
@@ -53,7 +53,7 @@ describe("Dataset", function() {
           let record = this.dataset.state.get(0);
           expect(this.server.requests.length).to.equal(1);
           expect(this.server.requests[0]).to.be.instanceOf(PageRequest);
-          expect(this.dataset.state.totalSize).to.equal(10);
+          expect(this.dataset.state.length).to.equal(10);
           expect(record).to.be.empty;
         });
       });


### PR DESCRIPTION
The expensive reduce function has been moved whenever the readOffset is set, and whenever we return a fetched page.