### PR TITLE
Add option to handle unfetched pages

### DIFF
--- a/src/dataset.js
+++ b/src/dataset.js
@@ -56,6 +56,7 @@ export default class Dataset {
 
     this._pageSize = options.pageSize;
     this._fetch = options.fetch;
+    this._unfetch = options.unfetch || function() {};
     this._observe = options.observe || function() {};
     // this._loadHorizon = options.loadHorizon || 1;
     // this._unloadHorizon = options.unloadHorizon || Infinity;
@@ -114,6 +115,7 @@ export default class Dataset {
   _unloadPage(pages, i) {
     let page = this._touchPage(pages, i);
     if (page.isRequested) {
+      this._unfetch.call(this, page.offset);
       page = page.unload();
       pages.splice(i, 1, page);
     }

--- a/src/dataset.js
+++ b/src/dataset.js
@@ -115,7 +115,7 @@ export default class Dataset {
   _unloadPage(pages, i) {
     let page = this._touchPage(pages, i);
     if (page.isRequested) {
-      this._unfetch.call(this, page.offset);
+      this._unfetch.call(this, page.data, page.offset);
       page = page.unload();
       pages.splice(i, 1, page);
     }
@@ -148,7 +148,7 @@ export default class Dataset {
 
   _adjustTotalRecords(state) {
     state.length = state.pages.reduce(function(length, page) {
-      return length + page.records.length;
+      return length + page.data.length;
     }, 0);
   }
 

--- a/test/dataset-test.js
+++ b/test/dataset-test.js
@@ -160,8 +160,8 @@ describe("Dataset", function() {
         fetch: (pageOffset, pageSize, stats) => {
           return this.server.request(pageOffset, pageSize, stats);
         },
-        unfetch: (pageOffset)=> {
-          return this.server.remove(pageOffset);
+        unfetch: (records, pageOffset)=> {
+          return this.server.remove(records, pageOffset);
         },
         observe: (state) => {
           this.state = state;

--- a/test/dataset-test.js
+++ b/test/dataset-test.js
@@ -160,6 +160,9 @@ describe("Dataset", function() {
         fetch: (pageOffset, pageSize, stats) => {
           return this.server.request(pageOffset, pageSize, stats);
         },
+        unfetch: (pageOffset)=> {
+          return this.server.remove(pageOffset);
+        },
         observe: (state) => {
           this.state = state;
         }
@@ -356,17 +359,27 @@ describe("Dataset", function() {
             expect(this.state.length).to.equal(50);
           });
 
-          it("unloads the page before the previous offset", function() {
+          it("unloads the resolved page before the previous offset", function() {
             var unrequestedPage = this.state.pages[1];
             expect(unrequestedPage.isRequested).to.be.false;
           });
 
-          it("does not unload the page before the current offset", function() {
+          it("unfetches the unloaded page", function() {
+            var unfetchedRequest = this.server.requests[1];
+            expect(unfetchedRequest).to.be.empty;
+          });
+
+          it("does not unload the page before the offset", function() {
             var loadedPage = this.state.pages[2];
             expect(loadedPage.isRequested).to.be.true;
           });
 
-          it('loads a single page of records before the offset', function () {
+          it("does not unfetch the requested page", function() {
+            var unfetchedRequest = this.server.requests[2];
+            expect(unfetchedRequest).to.not.be.empty;
+          });
+
+          it('loads a single page of records at the offset', function () {
             var beforeOffsetResolvedPages = this.state.pages[3];
             var record = this.state.get(30);
             expect(beforeOffsetResolvedPages.isRequested).to.be.true;

--- a/test/test-server.js
+++ b/test/test-server.js
@@ -42,7 +42,7 @@ export class Server {
     return this.requests[pageOffset] = new PageRequest(pageOffset, pageSize, stats);
   }
 
-  remove(pageOffset) {
+  remove(records, pageOffset) {
     let  unfetchedPage = this.requests[pageOffset];
     delete this.requests[pageOffset];
     return unfetchedPage;

--- a/test/test-server.js
+++ b/test/test-server.js
@@ -42,6 +42,12 @@ export class Server {
     return this.requests[pageOffset] = new PageRequest(pageOffset, pageSize, stats);
   }
 
+  remove(pageOffset) {
+    let  unfetchedPage = this.requests[pageOffset];
+    delete this.requests[pageOffset];
+    return unfetchedPage;
+  }
+
   /**
    * Resolve all requests that this server knows about, and return a
    * promise that can be used to synchronize the test case until all


### PR DESCRIPTION
Whenever a page is unloaded, the user has the ability to handle the unload page with the unfetch function. The most common use-case is to remove this data from the
application, such that it runs faster.

We need to updated the README to reflect this functionality