### PR TITLE
Return a record object for computed state.get(i)

### DIFF
--- a/src/dataset.js
+++ b/src/dataset.js
@@ -33,10 +33,10 @@ class State {
 
   get(index) {
     let pageOffset = Math.floor(index / this.pageSize);
-    let records = this.pages[pageOffset];
-    if (records) {
+    let page = this.pages[pageOffset];
+    if (page) {
       let recordOffset = index % this.pageSize;
-      return records.data[recordOffset];
+      return page.records[recordOffset];
     } else {
       return undefined;
     }

--- a/test/dataset-test.js
+++ b/test/dataset-test.js
@@ -50,11 +50,17 @@ describe("Dataset", function() {
           this.dataset.setReadOffset(0);
         });
         it("begins the process of fetching a page", function() {
-          let record = this.dataset.state.get(0);
           expect(this.server.requests.length).to.equal(1);
           expect(this.server.requests[0]).to.be.instanceOf(PageRequest);
           expect(this.dataset.state.length).to.equal(10);
-          expect(record).to.be.empty;
+        });
+        it("has a set of records", function() {
+          let record = this.dataset.state.get(0);
+          expect(record).to.be.instanceOf(Object);
+          expect(record.isRequested).to.be.true;
+          expect(record.index).to.equal(0);
+          expect(record.page.offset).to.equal(0);
+          expect(record.content).to.be.empty;
         });
       });
     });
@@ -292,22 +298,29 @@ describe("Dataset", function() {
         });
 
         it("has an empty set of records on the first page", function() {
-          var record = this.state.get(0);
-          expect(record).to.be.empty;
-
+          let record = this.dataset.state.get(0);
+          expect(record.isRequested).to.be.false;
+          expect(record.index).to.equal(0);
+          expect(record.page.offset).to.equal(0);
+          expect(record.content).to.be.empty;
         });
 
         it('loads a single page of records before the offset', function () {
           let index = this.initialReadOffset - this.recordsPerPage;
           var record = this.state.get(index);
-          expect(record).to.exist;
+          expect(record.isResolved).to.be.true;
+          expect(record.index).to.equal(0);
+          expect(record.page.offset).to.equal(1);
+          expect(record.content.name).to.equal('Record 10');
         });
 
         it('loads a single page of records at the offset', function () {
           let index = this.initialReadOffset;
-          var record = this.state.get(index);
+          var record = this.state.get(index + 1);
           expect(record).to.exist;
-          expect(record.name).to.equal('Record 20');
+          expect(record.index).to.equal(1);
+          expect(record.page.offset).to.equal(2);
+          expect(record.content.name).to.equal('Record 21');
         });
       });
 
@@ -326,23 +339,29 @@ describe("Dataset", function() {
           expect(this.state.pages.length).to.equal(3);
         });
 
-        it("does not have data defined on the first page", function() {
+        it("has an empty set of record on the first page", function() {
           var record = this.state.get(0);
-          expect(record).to.be.empty;
+          expect(record).to.exist;
+          expect(record.index).to.equal(0);
+          expect(record.page.offset).to.equal(0);
+          expect(record.content).to.be.empty;
         });
 
         it('loads a single page of records before the offset', function () {
           var beforeOffsetResolvedPages = this.state.pages[1];
           var record = this.state.get(10);
           expect(beforeOffsetResolvedPages.isRequested).to.be.true;
-          expect(record.name).to.equal('Record 10');
+          expect(record.isRequested).to.be.true;
+          expect(record.page.offset).to.equal(1);
+          expect(record.content).not.to.be.empty;
+          expect(record.content.name).to.equal('Record 10');
         });
 
         it('loads a single page of records after the offset', function () {
           var afterOffsetResolvedPages = this.state.pages[2];
           var record = this.state.get(20);
           expect(afterOffsetResolvedPages.isRequested).to.be.true;
-          expect(record.name).to.equal('Record 20');
+          expect(record.content.name).to.equal('Record 20');
         });
 
         describe("incrementing the readOffset by the unload horizon", function() {
@@ -381,14 +400,14 @@ describe("Dataset", function() {
             var beforeOffsetResolvedPages = this.state.pages[3];
             var record = this.state.get(30);
             expect(beforeOffsetResolvedPages.isRequested).to.be.true;
-            expect(record.name).to.equal('Record 30');
+            expect(record.content.name).to.equal('Record 30');
           });
 
           it('loads a single page of records after the offset', function () {
             var afterOffsetResolvedPages = this.state.pages[4];
             var record = this.state.get(40);
             expect(afterOffsetResolvedPages.isRequested).to.be.true;
-            expect(record.name).to.equal('Record 40');
+            expect(record.content.name).to.equal('Record 40');
           });
         });
 
@@ -407,21 +426,21 @@ describe("Dataset", function() {
             var beforeOffsetResolvedPages = this.state.pages[1];
             var record = this.state.get(10);
             expect(beforeOffsetResolvedPages.isRequested).to.be.true;
-            expect(record.name).to.equal('Record 10');
+            expect(record.content.name).to.equal('Record 10');
           });
 
           it('loads a single page of records at the offset', function () {
             var atOffsetResolvedPages = this.state.pages[2];
             var record = this.state.get(20);
             expect(atOffsetResolvedPages.isRequested).to.be.true;
-            expect(record.name).to.equal('Record 20');
+            expect(record.content.name).to.equal('Record 20');
           });
 
           it('loads a single page of records after the offset', function () {
             var afterOffsetResolvedPages = this.state.pages[3];
             var record = this.state.get(30);
             expect(afterOffsetResolvedPages.isRequested).to.be.true;
-            expect(record.name).to.equal('Record 30');
+            expect(record.content.name).to.equal('Record 30');
           });
         });
 


### PR DESCRIPTION
When we get a record on the state using state.get(i) return the `Record`
object, not just the content on the `Record`. We want the flight status
of the record to be on the record.