### PR TITLE
Define the attributes and content on unrequesteds

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,13 +59,7 @@ want to start reading from.
 
 ```javascript
 state.length //=> 0;
-let record = state.get(0);
-record.isRequested //=> false
-record.isPending //=> false
-record.isResolved //=> false
-record.index //=> null
-record.content //=> null
-record.page //=> { offset: null, size: 0, data: [] }
+state.get(0) //=> null;
 ```
 
 To tell where to start reading, you update the dataset's "read
@@ -88,7 +82,6 @@ record.isPending //=> true
 record.isResolved //=> false
 record.index //=> 2
 record.content //=> null
-record.page //=> { offset: 1, size: 5, data: [null*5] }
 ```
 
 ### Load Horizon

--- a/README.md
+++ b/README.md
@@ -59,7 +59,13 @@ want to start reading from.
 
 ```javascript
 state.length //=> 0;
-state.get(0) //=> null;
+let record = state.get(0);
+record.isRequested //=> false
+record.isPending //=> false
+record.isResolved //=> false
+record.index //=> null
+record.content //=> null
+record.page //=> { offset: null, size: 0, data: [] }
 ```
 
 To tell where to start reading, you update the dataset's "read
@@ -77,9 +83,12 @@ and emit a new state indicating that these records are in flight.
 ```javascript
 state.length //=> 10
 let record = state.get(7)
+record.isRequested //=> true
 record.isPending //=> true
 record.isResolved //=> false
+record.index //=> 2
 record.content //=> null
+record.page //=> { offset: 1, size: 5, data: [null*5] }
 ```
 
 ### Load Horizon

--- a/src/dataset.js
+++ b/src/dataset.js
@@ -40,8 +40,7 @@ class State {
     if (page) {
         return page.records[recordOffset];
     } else {
-      let page = new Page();
-      return new Record(page, page.data[recordOffset], recordOffset);
+      return new Record();
     }
   }
 }

--- a/src/page.js
+++ b/src/page.js
@@ -7,11 +7,11 @@ class UnrequestedPage {
     this.data = new Array(size).fill(null);
   }
 
-  get isRequested() { return (this.isSettled || this.isPending); }
+  get isRequested() { return this.isPending || this.isResolved || this.isRejected; }
   get isPending() { return false; }
   get isResolved() { return false; }
   get isRejected() { return false; }
-  get isSettled() { return false; }
+  get isSettled() { return !this.isPending && (this.isResolved || this.isRejected); }
 
   get records() {
     if (!this._records) {

--- a/src/page.js
+++ b/src/page.js
@@ -1,10 +1,10 @@
 import Record from './record';
 
 class UnrequestedPage {
-  constructor(offset, size) {
+  constructor(offset = null, size = 0) {
     this.offset = offset;
-    this.size = size || 0;
-    this.data = new Array(size).fill({});
+    this.size = size;
+    this.data = new Array(size).fill(null);
   }
 
   get isRequested() { return (this.isSettled || this.isPending); }

--- a/src/record.js
+++ b/src/record.js
@@ -1,5 +1,7 @@
+import Page from './page';
+
 class Record {
-  constructor(page, content, index) {
+  constructor(page = new Page(), content = null, index = null) {
     this.page = page;
     this.content = content;
     this.index = index;

--- a/test/dataset-test.js
+++ b/test/dataset-test.js
@@ -41,8 +41,7 @@ describe("Dataset", function() {
         expect(this.dataset._observe).to.be.instanceOf(Function);
       });
 
-      it("initializes an unrequested state", function() {
-        expect(this.dataset.state.isRequested).to.be.false;
+      it("initializes the state", function() {
         expect(this.dataset.state.isPending).to.be.false;
         expect(this.dataset.state.isResolved).to.be.false;
         expect(this.dataset.state.isRejected).to.be.false;
@@ -60,24 +59,9 @@ describe("Dataset", function() {
         expect(this.server.requests.length).to.equal(0);
       });
 
-      describe("getting a record", function() {
-        beforeEach(function() {
-          this.record = this.dataset.state.get(0);
-        });
-        it("returns an unrequested record", function() {
-          let record = this.record;
-          expect(record.isRequested).to.be.false;
-          expect(record.page).to.not.be.empty;
-          expect(record.index).to.equal(null);
-          expect(record.content).to.equal(null);
-        });
-        it("has an unrequested empty page on the record", function() {
-          let page = this.record.page;
-          expect(page.isRequested).to.be.false;
-          expect(page.size).to.equal(0);
-          expect(page.offset).to.equal(null);
-          expect(page.data.length).to.equal(0);
-        });
+      it("does not have any records", function() {
+        let record = this.dataset.state.get(0);
+        expect(record).to.equal(null);
       });
 
       describe("fetching a page", function() {
@@ -125,13 +109,30 @@ describe("Dataset", function() {
       this.dataset.setReadOffset(0);
       this.initialState = this.state;
     });
-    describe("resolving a fetch request", function() {
+    describe("resolving all fetch request", function() {
       beforeEach(function() {
+        return this.server.resolveAll();
+      });
+      it("transitions to a new Resolved state", function() {
+        expect(this.state).not.to.equal(this.initialState);
+        expect(this.state.isResolved).to.be.true;
+      });
+      it("resolves records", function () {
+        expect(this.state.length).to.equal(10);
+        var record = this.state.get(0);
+        expect(record.isResolved).to.be.true;
+        expect(record.content.name).to.equal("Record 0");
+      });
+    });
+
+    describe("resolving a fetch request", function() {
+      beforeEach(function(done) {
         let records = Array.from(Array(10)).map((_, i)=> {
           return {name: `Record ${i}`};
         });
         let request = this.requests[0];
-        return request.resolve(records);
+        let finish = ()=> done();
+        return request.resolve(records).then(finish).catch(finish);
       });
       it("transitions to a new Resolved state", function() {
         expect(this.state).not.to.equal(this.initialState);
@@ -385,101 +386,104 @@ describe("Dataset", function() {
         });
       });
     });
-  });
 
-  describe("Statistics ", function() {
-    beforeEach(function() {
-      this.server = new Server();
-      this.numFetchedPages = function() {
-        return this.server.requests.reduce(function(num, request) {
-          return (request instanceof PageRequest) ? num + 1 : num;
-        }, 0);
-      };
-    });
-
-    describe("when fetch() returns totalPages", function() {
+    describe("Statistics ", function() {
       beforeEach(function() {
-        this.totalPages = 10;
-        this.options = {
-          pageSize: 10,
-          fetch: (pageOffset, pageSize, stats) => {
-            stats.totalPages = 10;
-            return this.server.request(pageOffset, pageSize, stats);
-          },
-          unfetch: (records, pageOffset)=> {
-            return this.server.remove(records, pageOffset);
-          },
-          observe: (state) => {
-            this.state = state;
-          }
+        this.server = new Server();
+        this.numFetchedPages = function() {
+          return this.server.requests.reduce(function(num, request) {
+            return (request instanceof PageRequest) ? num + 1 : num;
+          }, 0);
         };
-        this.dataset = new Dataset(this.options);
-        this.dataset.setReadOffset(0);
       });
 
-      it("makes one request", function() {
-        expect(this.numFetchedPages()).to.equal(1);
-      });
-
-      describe("resolving the request with totalPages stats", function() {
+      describe("when fetch() returns totalPages", function() {
         beforeEach(function() {
-          return this.server.resolveAll();
+          this.totalPages = 10;
+          this.options = {
+            pageSize: 10,
+            fetch: (pageOffset, pageSize, stats) => {
+              stats.totalPages = 10;
+              return this.server.request(pageOffset, pageSize, stats);
+            },
+            unfetch: (records, pageOffset)=> {
+              return this.server.remove(records, pageOffset);
+            },
+            observe: (state) => {
+              this.state = state;
+            }
+          };
+          this.dataset = new Dataset(this.options);
+          this.dataset.setReadOffset(0);
         });
 
-        it("sets total pages", function() {
-          expect(this.state.stats.totalPages).to.equal(10);
-          expect(this.state.length).to.equal(100);
+        it("makes one request", function() {
+          expect(this.numFetchedPages()).to.equal(1);
         });
 
-        describe("Setting readOffset out of bounds", function() {
+        describe("resolving the request with totalPages stats", function() {
           beforeEach(function() {
-            this.prevRequestCount = this.server.requests.length;
+            return this.server.resolveAll();
           });
-          describe("where the minimum loadHorizon is less than the dataset length", function() {
-            beforeEach(function() {
-              let minLoadHorizon = this.state.length - 1;
-              this.dataset.setReadOffset(minLoadHorizon + this.state.loadHorizon);
-            });
-            it("makes one additional request", function() {
-              expect(this.numFetchedPages()).to.equal(this.prevRequestCount + 1);
-            });
-            it("requests the last page", function() {
-              expect(this.state.pages[9].isRequested).to.be.true;
-            });
-          });
-          describe("where the minimum loadHorizon is greater than or equal to the dataset length", function() {
-            beforeEach(function() {
-              let minLoadHorizon = this.state.length;
-              this.dataset.setReadOffset(minLoadHorizon + this.state.loadHorizon);
-            });
 
-            it("does not make any additional request", function() {
-              expect(this.numFetchedPages()).to.equal(this.prevRequestCount);
-              expect(this.state.length).to.equal(100);
+          it("sets total pages", function() {
+            expect(this.state.stats.totalPages).to.equal(10);
+            expect(this.state.length).to.equal(100);
+          });
+
+          describe("Setting readOffset out of bounds", function() {
+            beforeEach(function() {
+              this.prevRequestCount = this.server.requests.length;
             });
-            it("sets the readOffset at the out of bounds index", function() {
-              expect(this.state.readOffset).to.equal(110);
+            describe("where the minimum loadHorizon is less than the dataset length", function() {
+              beforeEach(function() {
+                let minLoadHorizon = this.state.length - 1;
+                this.dataset.setReadOffset(minLoadHorizon + this.state.loadHorizon);
+              });
+              it("makes one additional request", function() {
+                expect(this.numFetchedPages()).to.equal(this.prevRequestCount + 1);
+              });
+              it("requests the last page", function() {
+                expect(this.recordAtPage(9).isRequested).to.be.true;
+              });
+              it("does not have a record at the readOffset", function() {
+                let record = this.dataset.state.get(100);
+                expect(record).to.equal(null);
+              });
+              it("is in a pending state", function() {
+                expect(this.state.isPending).to.be.true;
+              });
             });
-            it("has an unrequested state", function() {
-              expect(this.state.isRequested).to.be.false;
-            });
-            it("has an unrequested record at the readOffset", function() {
-              let record = this.dataset.state.get(110);
-              expect(record.isRequested).to.be.false;
+            describe("where the minimum loadHorizon is greater than or equal to the dataset length", function() {
+              beforeEach(function() {
+                let minLoadHorizon = this.state.length;
+                this.dataset.setReadOffset(minLoadHorizon + this.state.loadHorizon);
+              });
+
+              it("does not make any additional request", function() {
+                expect(this.numFetchedPages()).to.equal(this.prevRequestCount);
+                expect(this.state.length).to.equal(100);
+              });
+              it("sets the readOffset at the out of bounds index", function() {
+                expect(this.state.readOffset).to.equal(110);
+              });
+              it("is not in a pending state", function() {
+                expect(this.state.isPending).to.be.false;
+              });
             });
           });
         });
-      });
 
-      describe("rejecting the request with totalPages stats", function() {
-        beforeEach(function(done) {
-          let finish = ()=> done();
-          return this.server.requests[0].reject().then(finish).catch(finish);
-        });
+        describe("rejecting the request with totalPages stats", function() {
+          beforeEach(function(done) {
+            let finish = ()=> done();
+            return this.server.requests[0].reject().then(finish).catch(finish);
+          });
 
-        it("sets the total pages", function() {
-          expect(this.state.stats.totalPages).to.equal(10);
-          expect(this.state.length).to.equal(100);
+          it("sets the total pages", function() {
+            expect(this.state.stats.totalPages).to.equal(10);
+            expect(this.state.length).to.equal(100);
+          });
         });
       });
     });

--- a/test/dataset-test.js
+++ b/test/dataset-test.js
@@ -41,7 +41,15 @@ describe("Dataset", function() {
         expect(this.dataset._observe).to.be.instanceOf(Function);
       });
 
-      it("initializes the state", function() {
+      it("initializes an unrequested state", function() {
+        expect(this.dataset.state.isRequested).to.be.false;
+        expect(this.dataset.state.isPending).to.be.false;
+        expect(this.dataset.state.isResolved).to.be.false;
+        expect(this.dataset.state.isRejected).to.be.false;
+        expect(this.dataset.state.isSettled).to.be.false;
+      });
+
+      it("initializes the state attributes", function() {
         expect(this.dataset.state).to.be.instanceOf(Object);
         expect(this.dataset.state.length).to.equal(0);
         expect(this.dataset.state.loadHorizon).to.equal(10);
@@ -50,6 +58,26 @@ describe("Dataset", function() {
 
       it("does not fetch a page", function() {
         expect(this.server.requests.length).to.equal(0);
+      });
+
+      describe("getting a record", function() {
+        beforeEach(function() {
+          this.record = this.dataset.state.get(0);
+        });
+        it("returns an unrequested record", function() {
+          let record = this.record;
+          expect(record.isRequested).to.be.false;
+          expect(record.page).to.not.be.empty;
+          expect(record.index).to.equal(null);
+          expect(record.content).to.equal(null);
+        });
+        it("has an unrequested empty page on the record", function() {
+          let page = this.record.page;
+          expect(page.isRequested).to.be.false;
+          expect(page.size).to.equal(0);
+          expect(page.offset).to.equal(null);
+          expect(page.data.length).to.equal(0);
+        });
       });
 
       describe("fetching a page", function() {
@@ -71,7 +99,7 @@ describe("Dataset", function() {
           expect(record.isPending).to.be.true;
           expect(record.isResolved).to.be.false;
           expect(record.isRejected).to.be.false;
-          expect(record.content).to.be.empty;
+          expect(record.content).to.equal(null);
           expect(record.page.offset).to.equal(0);
         });
       });
@@ -183,7 +211,7 @@ describe("Dataset", function() {
       };
     });
 
-    describe("with setReadOffset at the start of the dataset", function () {
+    describe("setting readOffset to zero", function () {
       beforeEach(function() {
         this.initialReadOffset = 0;
       });
@@ -251,7 +279,7 @@ describe("Dataset", function() {
       });
     });
 
-    describe("with setReadOffset at the middle of the dataset", function() {
+    describe("setting readOffset to a large offset", function() {
       beforeEach(function() {
         this.initialReadOffset = 50;
       });
@@ -403,50 +431,45 @@ describe("Dataset", function() {
           expect(this.state.length).to.equal(100);
         });
 
-        describe("Setting the offset to the end of the dataset", function() {
+        describe("Setting readOffset out of bounds", function() {
           beforeEach(function() {
             this.prevRequestCount = this.server.requests.length;
-            this.dataset.setReadOffset(100);
           });
-          it("makes one additional request", function() {
-            expect(this.numFetchedPages()).to.equal(this.prevRequestCount + 1);
+          describe("where the minimum loadHorizon is less than the dataset length", function() {
+            beforeEach(function() {
+              let minLoadHorizon = this.state.length - 1;
+              this.dataset.setReadOffset(minLoadHorizon + this.state.loadHorizon);
+            });
+            it("makes one additional request", function() {
+              expect(this.numFetchedPages()).to.equal(this.prevRequestCount + 1);
+            });
+            it("requests the last page", function() {
+              expect(this.state.pages[9].isRequested).to.be.true;
+            });
           });
-        });
+          describe("where the minimum loadHorizon is greater than or equal to the dataset length", function() {
+            beforeEach(function() {
+              let minLoadHorizon = this.state.length;
+              this.dataset.setReadOffset(minLoadHorizon + this.state.loadHorizon);
+            });
 
-        describe("Setting the offset past the loadHorizon boundary of the dataset", function() {
-          beforeEach(function() {
-            this.prevRequestCount = this.server.requests.length;
-            this.dataset.setReadOffset(110);
-          });
-
-          it("does not make any additional request", function() {
-            expect(this.numFetchedPages()).to.equal(this.prevRequestCount);
-            expect(this.state.length).to.equal(100);
-          });
-          it("sets the readOffset at the out of bounds index", function() {
-            expect(this.state.readOffset).to.equal(110);
-          });
-          it("has an unrequested state", function() {
-            expect(this.state.isRequested).to.be.false;
-            expect(this.state.isPending).to.be.false;
-            expect(this.state.isResolved).to.be.false;
-            expect(this.state.isRejected).to.be.false;
-            expect(this.state.isSettled).to.be.false;
-          });
-          it("has an unrequested record at the readOffset", function() {
-            let record = this.dataset.state.get(110);
-            expect(record.isRequested).to.be.false;
-          });
-          it("has an unrequested empty page on the record", function() {
-            let page = this.dataset.state.get(110).page;
-            expect(page.isRequested).to.be.false;
-            expect(page.offset).to.be.empty;
-            expect(page.size).to.equal(0);
-            expect(page.data).deep.equal([{}]);
+            it("does not make any additional request", function() {
+              expect(this.numFetchedPages()).to.equal(this.prevRequestCount);
+              expect(this.state.length).to.equal(100);
+            });
+            it("sets the readOffset at the out of bounds index", function() {
+              expect(this.state.readOffset).to.equal(110);
+            });
+            it("has an unrequested state", function() {
+              expect(this.state.isRequested).to.be.false;
+            });
+            it("has an unrequested record at the readOffset", function() {
+              let record = this.dataset.state.get(110);
+              expect(record.isRequested).to.be.false;
+            });
           });
         });
       });
-
 
       describe("rejecting the request with totalPages stats", function() {
         beforeEach(function(done) {


### PR DESCRIPTION
Defines and Documents the attributes and state of an Unrequested Record
and an Unrequested Page.

These can be created via API calls:
`state.get(i); // Where i >= state.length`
`dataset.setReadOffset(i); // Where i >= state.length`