### PR TITLE
replace Array.prototype.fill usage with a function

### DIFF
--- a/src/page.js
+++ b/src/page.js
@@ -1,10 +1,18 @@
 import Record from './record';
 
+// Array.prototype.fill
+function fill(array, value) {
+  for (let i = 0; i < array.length; i++) {
+    array[i] = value;
+  }
+  return array;
+}
+
 class UnrequestedPage {
   constructor(offset = null, size = 0) {
     this.offset = offset;
     this.size = size;
-    this.data = new Array(size).fill(null);
+    this.data = fill(new Array(size), null);
   }
 
   get isRequested() { return this.isPending || this.isResolved || this.isRejected; }


### PR DESCRIPTION
Array.prototype.fill isn't available yet in all the browsers. Easier to
keep compatibility with mobile browsers and older versions of IE.