### PR TITLE
Apply refresh and reset actions to impagination

### DIFF
--- a/src/page.js
+++ b/src/page.js
@@ -65,11 +65,6 @@ class ResolvedPage extends PendingPage {
   get isPending() { return false; }
   get isResolved() { return true; }
   get isSettled() { return true; }
-
-  // Redundant, since we can call resolvedPage.resolve(resolvedPage.unfilteredRecords, resolvedPage.filterCallback) to reapply filters
-  filter(){
-    return new ResolvedPage(this, this.unfilteredData, this.filterCallback);
-  }
 }
 
 class RejectedPage extends PendingPage {


### PR DESCRIPTION
Fix #27 
refresh(readOffset) will reapply filters on all pages from the given offset (defaultOffset: currentOffset)
reset(readOffset)   will unload and refetch all pages from the given offset (defaultOffset: 0)