### PR TITLE
Add `util` to the dependencies for impagination

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 /node_modules
+/lib
+/yarn.lock

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   },
   "dependencies": {
     "babel-runtime": "^5.8.25",
-    "binary-search-tree": "^0.2.6"
+    "binary-search-tree": "^0.2.6",
+    "util": "^0.10.3"
   }
 }


### PR DESCRIPTION
binary-search-tree requires `util`, but does not enumerate it as a dependency. This is a known issue with it https://github.com/louischatriot/node-binary-search-tree/issues/14

This adds `util` as a primary dependency so that this require will not fail. While we're fixing up meta-information, this adds build time artifacts  `/lib` and `/yarn.lock` to the ignore list.

Fixes #38 and #40 